### PR TITLE
remove deprecated call to bottle :unneeded

### DIFF
--- a/Formula/f1viewer.rb
+++ b/Formula/f1viewer.rb
@@ -6,7 +6,6 @@ class F1viewer < Formula
   desc "TUI client for F1TV"
   homepage "https://github.com/SoMuchForSubtlety/f1viewer/"
   version "2.3.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Running `brew update` reported this warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the somuchforsubtlety/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/somuchforsubtlety/homebrew-tap/Formula/f1viewer.rb:9
```

According to https://github.com/Homebrew/discussions/discussions/2311 this was a no-op for formulae outside of core anyway, so I just removed it.